### PR TITLE
Improve Firebase private key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Firebase configuration
+
+The application uses Firebase Admin from server-side API routes. The private
+key required by Firebase can be provided in two different ways:
+
+1. **Raw PEM string** – paste the key directly into the `FIREBASE_PRIVATE_KEY`
+   environment variable (including line breaks). When using the Vercel
+   dashboard, press `Shift + Enter` to insert real line breaks.
+2. **Base64 encoded string** – store a base64 representation of the key in the
+   variable. The application will automatically decode the value during
+   initialization.
+
+Other required variables are `FIREBASE_PROJECT_ID` and `FIREBASE_CLIENT_EMAIL`.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/src/lib/firebaseAdmin.ts
+++ b/src/lib/firebaseAdmin.ts
@@ -1,8 +1,25 @@
 // src/lib/firebaseAdmin.ts
 import * as admin from "firebase-admin";
 
+/**
+ * Decode the private key provided via environment variable.
+ *
+ * The value may be supplied either as a raw PEM string (with literal
+ * newlines or escaped \n sequences) or as a base64 encoded version of the
+ * PEM file.  This helper attempts to handle both cases gracefully so that
+ * deployments can configure the variable in whichever format is most
+ * convenient.
+ */
 function decodePrivateKey(encoded: string): string {
-  return Buffer.from(encoded, "base64").toString("utf-8");
+  // If the string already contains the BEGIN marker we assume it is the raw
+  // key possibly with escaped newlines.
+  if (encoded.includes("BEGIN PRIVATE KEY")) {
+    return encoded.replace(/\\n/g, "\n");
+  }
+
+  // Otherwise attempt to treat it as base64 encoded data.
+  const decoded = Buffer.from(encoded, "base64").toString("utf-8");
+  return decoded.replace(/\\n/g, "\n");
 }
 
 if (!admin.apps.length) {


### PR DESCRIPTION
## Summary
- handle multiline or base64-encoded Firebase private keys
- document Firebase environment variables in README

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68702c47380c832d985f4a3a2b0fc162